### PR TITLE
Use get_spotify_devices method in getSpotifyConnectDeviceId

### DIFF
--- a/custom_components/spotcast/__init__.py
+++ b/custom_components/spotcast/__init__.py
@@ -357,7 +357,7 @@ def setup(hass, config):
             client.start_playback(**kwargs)
 
     def getSpotifyConnectDeviceId(client, device_name):
-        devices_available = client.devices()
+        devices_available = get_spotify_devices(hass, client._get("me")["id"])
         for device in devices_available["devices"]:
             if device["name"] == device_name:
                 return device["id"]


### PR DESCRIPTION
```devices_available = client.devices()``` was returning an object with no devices, whereas using get_spotify_devices method seems to work